### PR TITLE
Re-added the vanished Browser

### DIFF
--- a/example/testbrowser/Main.elm
+++ b/example/testbrowser/Main.elm
@@ -1,0 +1,40 @@
+import Check exposing (..)
+import Check.Investigator exposing (..)
+import Check.Runner.Browser exposing (display)
+import Result exposing (Result)
+
+reverse : List a -> List a
+reverse ls = List.reverse ls
+
+claim_reverse_twice_yields_original =
+  claim
+    "Reversing a list twice yields the original list"
+  `that`
+    (\list -> reverse (reverse list))
+  `is`
+    (identity)
+  `for`
+    list int
+
+
+claim_reverse_does_not_modify_length =
+  claim
+    "Reversing a list does not modify its length"
+  `that`
+    (\list -> List.length (reverse list))
+  `is`
+    (\list -> List.length list)
+  `for`
+    list int
+
+
+suite_reverse =
+  suite "reverse list Suite"
+    [ claim_reverse_twice_yields_original
+    , claim_reverse_does_not_modify_length 
+    ]
+
+result = quickCheck suite_reverse
+
+main = display result
+

--- a/example/testbrowser/elm-package.json
+++ b/example/testbrowser/elm-package.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.0.0",
+    "summary": "Property-based testing in Elm",
+    "repository": "https://github.com/NoRedInk/elm-check.git",
+    "license": "MIT",
+    "source-directories": [
+        "../../src"
+    ],
+    "exposed-modules": [
+    ],
+    "dependencies": {
+        "NoRedInk/elm-random-extra": "2.0.0 <= v < 3.0.0",
+        "NoRedInk/elm-shrink": "1.0.3 <= v < 2.0.0",
+        "NoRedInk/elm-lazy-list": "2.0.0 <= v < 3.0.0",
+        "deadfoxygrandpa/elm-test": "3.0.0 <= v < 4.0.0",
+        "evancz/elm-html": "4.0.2 <= v < 5.0.0",
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.16.0 <= v < 0.17.0"
+}

--- a/src/Check/Runner/Browser.elm
+++ b/src/Check/Runner/Browser.elm
@@ -1,0 +1,172 @@
+module Check.Runner.Browser
+  ( display
+  , displayVerbose
+  ) where
+{-| Browser test runner for elm-check. This module provides functions to
+run and visualize tests in the browser.
+# Display Test Results
+@docs display, displayVerbose
+-}
+
+import Check exposing (Evidence (..), UnitEvidence, SuccessOptions, FailureOptions)
+import Html exposing (Html, Attribute, div, text, ul, ol, li)
+import Html.Attributes exposing (style)
+import List
+
+
+(:::) = (,)
+
+type alias Style = List (String, String)
+
+
+pomegranate     = "#c0392b"
+backgroundBrown = "#DDCCA1"
+midnightBlue    = "#2c3e50"
+nephritis       = "#27ae60"
+
+toColor : Bool -> String
+toColor b =
+  if b
+  then
+    nephritis
+  else
+    pomegranate
+
+suiteStyle : Bool -> Style
+suiteStyle b =
+  [ "display"          ::: "flex"
+  , "flex-direction"   ::: "column"
+  , "color"            ::: toColor b
+  ]
+
+
+
+displayStyle : Style
+displayStyle =
+  [ "width"             ::: "100vw"
+  , "min-height"        ::: "100vh"
+  , "background-color"  ::: backgroundBrown
+  ]
+
+{-| Display test results in the browser.
+-}
+display : Evidence -> Html
+display evidence =
+  div
+    [ style displayStyle ]
+    [ display' False evidence ]
+
+
+{-| Verbose version of `display`. Contains additional information
+about the test results.
+-}
+displayVerbose : Evidence -> Html
+displayVerbose evidence =
+  div
+    [ style displayStyle ]
+    [ display' True evidence]
+
+display' : Bool -> Evidence -> Html
+display' b evidence = case evidence of
+  Unit unitEvidence ->
+    displayUnit b unitEvidence
+  Multiple name evidences ->
+    displaySuite b name evidences
+
+displaySuite : Bool -> String -> List Evidence -> Html
+displaySuite b name evidences =
+  li
+    [ style (suiteStyle (areOk evidences)) ]
+    [ text ("Suite: " ++ name)
+    , ol
+        []
+        (List.map (display' b) evidences)
+    ]
+
+
+isOk : Evidence -> Bool
+isOk evidence = case evidence of
+  Unit unitEvidence -> case unitEvidence of
+    Ok _ -> True
+    _ -> False
+  Multiple _ evidences ->
+    areOk evidences
+
+
+areOk : List Evidence -> Bool
+areOk evidences =
+  List.all ((==) True) (List.map isOk evidences)
+
+
+unitStyle : Bool -> Style
+unitStyle b =
+  [ "color"            ::: toColor b
+  , "margin-bottom"    ::: "5px"
+  , "margin-top"       ::: "10px"
+  ]
+
+
+unitInnerStyle : Style
+unitInnerStyle =
+  [ "color" ::: midnightBlue ]
+
+displayUnit : Bool -> UnitEvidence -> Html
+displayUnit b unitEvidence = case unitEvidence of
+  Ok options ->
+    li
+      [ style (unitStyle True) ]
+      [ text (successMessage options) ]
+
+  Err options ->
+    let
+        essentialParts =
+          [ li
+              []
+              [ text ("Counter example: " ++ options.counterExample) ]
+          , li
+              []
+              [ text ("Actual: " ++ options.actual) ]
+          , li
+              []
+              [ text ("Expected: " ++ options.expected)]
+
+          ]
+
+        verboseParts =
+          if not b then []
+          else
+            [ li
+                []
+                [ text ("Seed: " ++ (toString options.seed)) ]
+            , li
+                []
+                [ text ("Number of shrinking operations performed: " ++ (toString options.numberOfShrinks)) ]
+            , li
+                []
+                [ text "Before shrinking: "
+                , ul
+                    []
+                    [ li
+                        []
+                        [ text ("Counter example: " ++ options.original.counterExample) ]
+                    , li
+                        []
+                        [ text ("Actual: " ++ options.original.actual) ]
+                    , li
+                        []
+                        [ text ("Expected: " ++ options.original.expected) ]
+                    ]
+                ]
+            ]
+    in
+        li
+          [ style (unitStyle False) ]
+          [ text (options.name ++ " FAILED after " ++ (toString options.numberOfChecks) ++ " check"++ (if options.numberOfChecks == 1 then "" else "s") ++ "!")
+          , ul
+              [ style unitInnerStyle ]
+              (essentialParts ++ verboseParts)
+          ]
+
+successMessage : SuccessOptions -> String
+successMessage {name, seed, numberOfChecks} =
+  name ++ " passed after " ++ (toString numberOfChecks) ++ " checks."


### PR DESCRIPTION
(compatible with Elm 0.16)

I don't know how you want to package the browser.  In this PR, you still compile Check.elm with the original dependencies.  I've also put in an example testbrowser directory which includes the extra dependency on elm-html so that the test compiles but I've left this dependency out of the main source.  It obviously need fixing somehow so you're happy with the dependencies. 
