### PR TITLE
Add evidenceToTest and deprecation notices

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -15,7 +15,7 @@
         "NoRedInk/elm-random-extra": "2.0.0 <= v < 3.0.0",
         "NoRedInk/elm-shrink": "1.0.3 <= v < 2.0.0",
         "NoRedInk/elm-lazy-list": "2.0.0 <= v < 3.0.0",
-        "deadfoxygrandpa/elm-test": "3.0.0 <= v < 4.0.0",
+        "deadfoxygrandpa/elm-test": "3.1.0 <= v < 4.0.0",
         "elm-lang/core": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.16.0 <= v < 0.17.0"

--- a/src/Check.elm
+++ b/src/Check.elm
@@ -1,26 +1,11 @@
 module Check where
 {-| Property Based Testing module in Elm.
 
-# Make a claim
-@docs claim, claimTrue, claimFalse
+# A DSL for writing claims
 
-# Check a claim
-@docs quickCheck, check
-
-# Group claims into a suite
-@docs suite
-
-# Types
-@docs Claim, Evidence, UnitEvidence, SuccessOptions, FailureOptions
-
-# Multi-arity claims
-@docs claim2, claim2True, claim2False, claim3, claim3True, claim3False, claim4, claim4True, claim4False, claim5, claim5True, claim5False
-
-# DSL
-
-`elm-check` provides a shorthand DSL for authoring claims. The goal of this
-DSL is to help improve readability and encode intent in the phrasing of your
-test code.
+`elm-check` provides a shorthand domain-specific language (DSL) for authoring
+claims. The goal of this DSL is to help improve readability and encode intent in
+the phrasing of your test code.
 
 With the DSL, claims read as either:
 
@@ -59,7 +44,24 @@ are strictly necessary, they are there to ensure that the test is authored in
 a uniform way. As a result, the following functions have horrendous type
 signatures and you are better off ignoring them.*
 
-@docs that, is, for, true, false
+@docs claim, that, is, for, true, false
+
+# Check a claim
+@docs quickCheck, check
+
+# Group claims into a suite
+@docs suite
+
+# Types
+The results of checking a claim are given back in the types defined here. You
+can examine them yourself, or see `Check.Test` to convert them into tests to use
+with `elm-check`'s runners.
+@docs Claim, Evidence, UnitEvidence, SuccessOptions, FailureOptions
+
+# Deprecated claim functions
+These functions will be removed in 3.0.0. Use the DSL.
+@docs claimTrue, claimFalse, claim2, claim2True, claim2False, claim3, claim3True, claim3False, claim4, claim4True, claim4False, claim5, claim5True, claim5False
+
 
 -}
 

--- a/src/Check/Investigator.elm
+++ b/src/Check/Investigator.elm
@@ -42,6 +42,9 @@ type alias Investigator a =
 
 {-| Investigator constructor. Construct an Investigator from a generator and
 a shrinker.
+
+**Deprecation notice:** This function will be removed in 3.0.0. Use
+`Investigator` instead.
 -}
 investigator : Generator a -> Shrinker a -> Investigator a
 investigator generator shrinker =

--- a/src/Check/Test.elm
+++ b/src/Check/Test.elm
@@ -1,5 +1,9 @@
-module Check.Test where
+module Check.Test (evidenceToTest, test, assert, test2, test3, test4, test5, assert2, assert3, assert4, assert5) where
+
 {-| Submodule providing integration with elm-test.
+
+# Convert to tests
+@docs evidenceToTest
 
 # Generate unit tests
 @docs test, assert
@@ -8,11 +12,33 @@ module Check.Test where
 @docs test2, test3, test4, test5, assert2, assert3, assert4, assert5
 
 -}
+import Check
 import Check.Investigator as Investigator exposing (Investigator, tuple, tuple3, tuple4, tuple5)
 import Trampoline exposing (Trampoline(..), trampoline)
 import ElmTest as Test exposing (..)
 import Random exposing (Seed)
 import Lazy.List
+
+nChecks n = if n == 1 then "1 check" else toString n ++ " checks"
+
+{-| Convert elm-check's Evidence into an elm-test Test. You can use elm-test's
+runners to view the results of your property-based tests, alongside the results
+of unit tests.
+-}
+evidenceToTest : Check.Evidence -> Test.Test
+evidenceToTest evidence =
+  case evidence of
+    Check.Multiple name more ->
+      Test.suite name (List.map evidenceToTest more)
+
+    Check.Unit (Ok {name, numberOfChecks}) ->
+      Test.test (name ++ " [" ++ nChecks numberOfChecks ++ "]") Test.pass
+
+    Check.Unit (Err {name, numberOfChecks, expected, actual, counterExample}) ->
+      Test.test name <| Test.fail <|
+        "On check " ++ toString numberOfChecks ++ ", found counterexample: " ++
+        counterExample ++ " Expected " ++ expected ++ " but got " ++ actual
+
 
 {-| Analogous to `claim`. Will generate a given number of unit tests for given
 actual and expected statements. If a unit tests fails, `test` will also generate

--- a/src/Check/Test.elm
+++ b/src/Check/Test.elm
@@ -5,10 +5,13 @@ module Check.Test (evidenceToTest, test, assert, test2, test3, test4, test5, ass
 # Convert to tests
 @docs evidenceToTest
 
-# Generate unit tests
+# Deprecated functions
+Everything below this point will be removed in 3.0.0.
+
+## Generate unit tests
 @docs test, assert
 
-# Multi-arity
+## Multi-arity
 @docs test2, test3, test4, test5, assert2, assert3, assert4, assert5
 
 -}


### PR DESCRIPTION
This patch prepares for the release of 2.1.0 -- assuming the kind folks at NRI are okay with me doing this.

First, add `evidenceToTest : Check.Evidence -> ElmTest.Test`. This is a far superior way of handling the display of results: just hand them off to ElmTest and use those runners. A serious project will have both property-based and unit tests anyway, so it makes sense for them all to be tested in the same place.

Second, add deprecation notices to the functions I listed in #3. I think that `evidenceToTest` is a far better solution for integrating with elm-test than a second DSL, so that all gets removed. I am also planning on removing some other functions that I see as extraneous, but I'm open to someone say "no wait I use those!".

Once this is merged, I'll start cutting all the deprecated functions and revise the README to prepare for 3.0.0.
