### PR TITLE
Add keepIf and dropIf filters to Investigator

### DIFF
--- a/src/Check/Investigator.elm
+++ b/src/Check/Investigator.elm
@@ -15,7 +15,7 @@ migrating from local to cloud-based.
 @docs Investigator, investigator
 
 # Basic Investigator Generators
-@docs void, bool, order, random, int, rangeInt, float, percentage, char, upperCaseChar, lowerCaseChar, ascii, unicode, string, maybe, result, list, array, tuple, tuple3, tuple4, tuple5, func, func2, func3, func4, func5
+@docs void, bool, order, random, int, rangeInt, float, percentage, char, upperCaseChar, lowerCaseChar, ascii, unicode, string, maybe, result, list, array, tuple, tuple3, tuple4, tuple5, func, func2, func3, func4, func5, keepIf, dropIf
 
 -}
 import Array  exposing (Array)
@@ -259,6 +259,29 @@ tuple5 (invA, invB, invC, invD, invE) =
   investigator
     (Random.zip5 invA.generator invB.generator invC.generator invD.generator invE.generator)
     (Shrink.tuple5 (invA.shrinker, invB.shrinker, invC.shrinker, invD.shrinker, invE.shrinker))
+
+
+{-| Filter out an Investigator. The resulting Investigator will
+only generate random test values or shrunken values that
+satisfy the predicate. Uses the `keepIf` filter from
+elm-random-extra and the `keepIf` filter from elm-shrink.
+-}
+keepIf : (a -> Bool) -> Investigator a -> Investigator a
+keepIf predicate inv =
+  investigator
+    (Random.keepIf predicate inv.generator)
+    (Shrink.keepIf predicate inv.shrinker)
+
+{-| Filter out an Investigator. The resulting Investigator will
+only generate random test values or shrunken values that do not
+satisfy the predicate. Uses the `dropIf` filter from
+elm-random-extra and the `dropIf` filter from elm-shrink.
+-}
+dropIf : (a -> Bool) -> Investigator a -> Investigator a
+dropIf predicate inv =
+  investigator
+    (Random.dropIf predicate inv.generator)
+    (Shrink.dropIf predicate inv.shrinker)
 
 
 {-| Investigator of functions. Takes an investigator for the return type


### PR DESCRIPTION
Often times I'll want an `Investigator` that will only produce random values _and_ shrink to values that satisfy some predicate (ex. I want to test against only even `Int`s). To do this I would normally have to:

```
predicate : Int -> Bool
predicate n =
  n % 2 == 0

{
  generator: Check.Investigator.int |> Random.Extra.keepIf predicate
, shrinker: Shrink.int |> Shrink.keepIf predicate
}
```

If you forget to apply the filter to the shrinker it can lead to the case of a test failure inside the space of values you are trying to investigate being shrunk to a test failure outside the space of values you are trying to investigate.

This PR adds `keepIf` and `dropIf` filters that apply the same predicate filter to both the generator and the shrinker.

If you think this is outside what belongs in the core `elm-check` package I'd be happy to start an `elm-check-extra` or the like for helpers like this.
